### PR TITLE
Reintroduce and fix index model check.

### DIFF
--- a/modeltest.py
+++ b/modeltest.py
@@ -433,7 +433,7 @@ class ModelTest(QtCore.QObject):
                 assert( a == b )
 
                 # Some basic checking on the index that is returned
-                # assert( index.model() == self.model )
+                assert( index.model() == self._model )
                 # This raises an error that is not part of the qbzr code.
                 # see http://www.opensubscriber.com/message/pyqt@riverbankcomputing.com/10335500.html
                 assert( index.row() == r )

--- a/modeltest.py
+++ b/modeltest.py
@@ -434,8 +434,6 @@ class ModelTest(QtCore.QObject):
 
                 # Some basic checking on the index that is returned
                 assert( index.model() == self._model )
-                # This raises an error that is not part of the qbzr code.
-                # see http://www.opensubscriber.com/message/pyqt@riverbankcomputing.com/10335500.html
                 assert( index.row() == r )
                 assert( index.column() == c )
                 # While you can technically return a QtCore.QVariant usually this is a sign


### PR DESCRIPTION
This didn't work because it was comparing with self.model which is the model
which got cast to a QAbstractItemModel. When using the original model
(self._model) the check seems to pass fine.
